### PR TITLE
feat: expose windowing APIs to other plugins

### DIFF
--- a/main.js
+++ b/main.js
@@ -478,6 +478,11 @@ class TrayPlugin extends obsidian.Plugin {
     cleanup();
   }
 
+  getWindows = getWindows;
+  showWindows = showWindows;
+  hideWindows = hideWindows;
+  toggleWindows = toggleWindows;
+
   async loadSettings() {
     const DEFAULT_SETTINGS = OPTIONS.map((opt) => ({ [opt.key]: opt.default }));
     this.settings = Object.assign(...DEFAULT_SETTINGS, await this.loadData());


### PR DESCRIPTION
exposes:
- getWindows()
- showWindows()
- hideWindows()
- toggleWindows()